### PR TITLE
Add metrics to SwiftInputStream, SwiftOutputStream and SwiftAPIClient.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
         <powermock.version>1.6.1</powermock.version>
         <mockito.version>1.10.8</mockito.version>
+	<spark.version>[1.6.1,)</spark.version>
     </properties>
 
     <dependencies>
@@ -179,6 +180,15 @@
             <artifactId>httpcore</artifactId>
             <version>${httpcomponents.httpcore.version}</version>
         </dependency>
+        
+ 
+        <dependency>
+                  <groupId>org.apache.spark</groupId>
+                  <artifactId>spark-core_2.11</artifactId>
+                  <version>${spark.version}</version>
+                  <scope>provided</scope>
+        </dependency>
+        
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <httpcomponents.httpclient.version>4.5.2</httpcomponents.httpclient.version>
         <powermock.version>1.6.1</powermock.version>
         <mockito.version>1.10.8</mockito.version>
-	<spark.version>[1.6.1,)</spark.version>
     </properties>
 
     <dependencies>
@@ -179,14 +178,6 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${httpcomponents.httpcore.version}</version>
-        </dependency>
-        
- 
-        <dependency>
-                  <groupId>org.apache.spark</groupId>
-                  <artifactId>spark-core_2.11</artifactId>
-                  <version>${spark.version}</version>
-                  <scope>provided</scope>
         </dependency>
         
         <!-- Test dependencies -->

--- a/src/main/java/com/ibm/stocator/fs/common/Constants.java
+++ b/src/main/java/com/ibm/stocator/fs/common/Constants.java
@@ -133,5 +133,9 @@ public class Constants {
    * JOSS synchronize with server time
    */
   public static final String JOSS_SYNC_SERVER_TIME = "fs.stocator.joss.synchronize.time";
-
+  /*
+   * Set stocator metrics on or off
+   */
+  public static final String METRICS_TOGGLE = "fs.stocator.metrics.toggle";
+  public static final String METRICS_TOGGLE_ON = "ON";
 }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIClient.java
@@ -54,6 +54,7 @@ import com.ibm.stocator.fs.swift.auth.JossAccount;
 import com.ibm.stocator.fs.swift.auth.PasswordScopeAccessProvider;
 import com.ibm.stocator.fs.swift.http.ConnectionConfiguration;
 import com.ibm.stocator.fs.swift.http.SwiftConnectionManager;
+import com.ibm.stocator.metrics.DataMetricUtilities;
 
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.map.SerializationConfig;
@@ -164,6 +165,8 @@ public class SwiftAPIClient implements IStoreClient {
    */
   private ConnectionConfiguration connectionConfiguration = new ConnectionConfiguration();
 
+  private static final Logger METRICS_LOG = LoggerFactory.getLogger(DataMetricUtilities.class);
+
   /**
    * Constructor method
    *
@@ -183,6 +186,9 @@ public class SwiftAPIClient implements IStoreClient {
     cachedSparkJobsStatus = new HashMap<String, Boolean>();
     schemaProvided = scheme;
     Properties props = ConfigurationHandler.initialize(filesystemURI, conf);
+    if (Constants.METRICS_TOGGLE_ON.equals(conf.get(Constants.METRICS_TOGGLE))) {
+      DataMetricUtilities.enableMetricsLogging();
+    }
     connectionConfiguration.setExecutionCount(conf.getInt(Constants.EXECUTION_RETRY,
         ConnectionConfiguration.DEFAULT_EXECUTION_RETRY));
     connectionConfiguration.setMaxPerRoute(conf.getInt(Constants.MAX_PER_ROUTE,
@@ -274,11 +280,14 @@ public class SwiftAPIClient implements IStoreClient {
       }
     }
     Container containerObj = mJossAccount.getAccount().getContainer(container);
-    if (!authMethod.equals(PUBLIC_ACCESS) && !containerObj.exists()) {
-      containerObj.create();
+    if (!authMethod.equals(PUBLIC_ACCESS) && !containerExists(containerObj)) {
+      containerCreate(containerObj);
     }
 
     objectCache = new SwiftObjectCache(containerObj);
+    if (Constants.METRICS_TOGGLE_ON.equals(conf.get(Constants.METRICS_TOGGLE))) {
+      DataMetricUtilities.enableMetricsLogging();
+    }
   }
 
   @Override
@@ -340,7 +349,7 @@ public class SwiftAPIClient implements IStoreClient {
       // object exists, We need to check if the object size is equal to zero
       // If so, it might be a directory
       if (obj.getContentLength() == 0) {
-        Collection<DirectoryOrObject> directoryFiles = cont.listDirectory(objectName, '/', "", 10);
+        Collection<DirectoryOrObject> directoryFiles = listDirectory(cont, objectName);
         if (directoryFiles != null && directoryFiles.size() != 0) {
           // The zero length object is a directory
           isDirectory = true;
@@ -353,8 +362,7 @@ public class SwiftAPIClient implements IStoreClient {
     }
     // We need to check if it may be a directory with no zero byte file associated
     LOG.trace("Checking if directory without 0 byte object associated {}", objectName);
-    Collection<DirectoryOrObject> directoryFiles = cont.listDirectory(objectName + "/", '/',
-        "", 10);
+    Collection<DirectoryOrObject> directoryFiles = listDirectory(cont, objectName + "/");
     if (directoryFiles != null) {
       LOG.trace("{} got {} candidates", objectName + "/", directoryFiles.size());
     }
@@ -474,7 +482,7 @@ public class SwiftAPIClient implements IStoreClient {
     FileStatus fs = null;
     StoredObject previousElement = null;
     for (Integer page = 0; page < paginationMap.getNumberOfPages(); page++) {
-      Collection<StoredObject> res = cObj.list(paginationMap, page);
+      Collection<StoredObject> res = listContainer(cObj, paginationMap, page);
       if (page == 0 && (res == null || res.isEmpty())) {
         FileStatus[] emptyRes = {};
         LOG.debug("List {} in container {} is empty", obj, container);
@@ -587,7 +595,7 @@ public class SwiftAPIClient implements IStoreClient {
 
     try {
       return new FSDataOutputStream(new SwiftOutputStream(mJossAccount, url, contentType,
-              metadata, swiftConnectionManager), statistics);
+          metadata, swiftConnectionManager, objName), statistics);
     } catch (IOException e) {
       LOG.error(e.getMessage());
       throw e;
@@ -603,8 +611,8 @@ public class SwiftAPIClient implements IStoreClient {
     LOG.debug("Object name to delete {}. Path {}", obj, path.toString());
     StoredObject so = mJossAccount.getAccount().getContainer(container)
         .getObject(obj);
-    if (so.exists()) {
-      so.delete();
+    if (storedObjectExists(so)) {
+      storedObjectDelete(so);
       objectCache.remove(obj);
     }
     return true;
@@ -650,7 +658,7 @@ public class SwiftAPIClient implements IStoreClient {
     String obj = objectName;
     Boolean sparkOriginated = Boolean.FALSE;
     StoredObject so = mJossAccount.getAccount().getContainer(container).getObject(obj);
-    if (so != null && so.exists()) {
+    if (so != null && storedObjectExists(so)) {
       Object sparkOrigin = so.getMetadata("Data-Origin");
       if (sparkOrigin != null) {
         String tmp = (String) sparkOrigin;
@@ -680,10 +688,11 @@ public class SwiftAPIClient implements IStoreClient {
     String obj = objectName;
     Account account = mJossAccount.getAccount();
     LOG.trace("HEAD {}", obj + "/" + HADOOP_SUCCESS);
-    StoredObject so = account.getContainer(container).getObject(obj
+    Container cont = account.getContainer(container);
+    StoredObject so = containerGetObject(cont, obj
         + "/" + HADOOP_SUCCESS);
     Boolean isJobOK = Boolean.FALSE;
-    if (so.exists()) {
+    if (storedObjectExists(so)) {
       LOG.debug("{} exists", obj + "/" + HADOOP_SUCCESS);
       isJobOK = Boolean.TRUE;
     }
@@ -815,9 +824,111 @@ public class SwiftAPIClient implements IStoreClient {
     }
     LOG.debug("Rename modified from {} to {}", objNameSrc, objNameDst);
     Container cont = mJossAccount.getAccount().getContainer(container);
-    StoredObject so = cont.getObject(objNameSrc);
-    StoredObject soDst = cont.getObject(objNameDst);
-    so.copyObject(cont, soDst);
+    StoredObject so = containerGetObject(cont, objNameSrc);
+    StoredObject soDst = containerGetObject(cont, objNameDst);
+    storedObjectCopy(cont, so, soDst);
     return true;
   }
+
+  static void containerCreate(Container containerObj) {
+    String objectName = containerObj.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "Create Container");
+
+    containerObj.create();
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "CREATE", true/* isContainer */,
+          requestStartTime));
+    }
+  }
+
+  static boolean containerExists(Container containerObj) {
+    String objectName = containerObj.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "HEAD Container");
+
+    boolean containerExists = containerObj.exists();
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "HEAD", true/* isContainer */,
+          requestStartTime));
+    }
+    return containerExists;
+  }
+
+  static Collection<DirectoryOrObject> listDirectory(Container cont, String objectName) {
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "LIST DIRECTORY");
+
+    Collection<DirectoryOrObject> directoryListing = cont.listDirectory(objectName, '/', "", 10);
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "GET", true/* isContainer */,
+          requestStartTime));
+    }
+    return directoryListing;
+  }
+
+  static Collection<StoredObject> listContainer(Container cObj, PaginationMap paginationMap,
+      Integer page) {
+    String objectName = cObj.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "LIST CONTAINER");
+
+    Collection<StoredObject> containerListing = cObj.list(paginationMap, page);
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "GET", true/* isContainer */,
+          requestStartTime));
+    }
+    return containerListing;
+  }
+
+  static boolean storedObjectExists(StoredObject so) {
+    String objectName = so.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "HEAD OBJECT");
+
+    boolean storedObjectExists = so.exists();
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "HEAD", false/* isContainer */,
+          requestStartTime));
+    }
+    return storedObjectExists;
+  }
+
+  static StoredObject containerGetObject(Container cont, String objectName) {
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "GET OBJECT");
+
+    StoredObject obj = cont.getObject(objectName);
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "GET", false/* isContainer */,
+          requestStartTime));
+    }
+    return obj;
+  }
+
+  static void storedObjectCopy(Container cont, StoredObject so, StoredObject soDst) {
+    String objectName = soDst.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "COPY OBJECT");
+
+    so.copyObject(cont, soDst);
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG.trace(DataMetricUtilities.closeMetric(objectName, "COPY", false/* isContainer */,
+          requestStartTime));
+    }
+  }
+
+  static void storedObjectDelete(StoredObject so) {
+    String objectName = so.getName();
+    long requestStartTime = DataMetricUtilities.initMetric(objectName, "DELETE OBJECT");
+
+    so.delete();
+
+    if (DataMetricUtilities.isMetricsLoggingEnabled()) {
+      METRICS_LOG
+          .trace(DataMetricUtilities.closeMetric(objectName, "DELETE", false/* isContainer */,
+              requestStartTime));
+    }
+  }
+
 }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftConstants.java
@@ -60,5 +60,4 @@ public class SwiftConstants {
   public static final String FMODE_DELETE_TEMP_DATA = ".failure.mode.delete";
   public static final String FMODE_AUTOMATIC_DELETE_PROPERTY = Constants.FS_SWIFT2D
       + FMODE_DELETE_TEMP_DATA;
-
 }

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftInputStreamWrapper.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftInputStreamWrapper.java
@@ -20,6 +20,7 @@ package com.ibm.stocator.fs.swift;
 import java.io.IOException;
 
 import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 
 import com.ibm.stocator.fs.common.Utils;
@@ -31,6 +32,8 @@ public class SwiftInputStreamWrapper extends BaseInputStream {
    */
   private final HttpRequestBase httpRequest;
 
+  private final HttpResponse httpResponse;
+
   /*
    * no more left to read
    */
@@ -41,11 +44,13 @@ public class SwiftInputStreamWrapper extends BaseInputStream {
    */
   private HttpEntity httpEntity;
 
-  public SwiftInputStreamWrapper(HttpEntity entity, HttpRequestBase httpRequestT)
+  public SwiftInputStreamWrapper(HttpEntity entity, HttpRequestBase httpRequestT,
+      HttpResponse httpResponseT)
           throws IOException {
     super(entity.getContent());
     httpEntity = entity;
     httpRequest = httpRequestT;
+    httpResponse = httpResponseT;
   }
 
   @Override
@@ -62,6 +67,10 @@ public class SwiftInputStreamWrapper extends BaseInputStream {
 
   public HttpRequestBase getHttpRequest() {
     return httpRequest;
+  }
+
+  public HttpResponse getHttpResponse() {
+    return httpResponse;
   }
 
   @Override

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftObjectCache.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftObjectCache.java
@@ -59,8 +59,9 @@ public class SwiftObjectCache {
     SwiftCachedObject res = cache.get(objName);
     if (res == null) {
       LOG.trace("Cache get:  {} is not in the cache. Access Swift to get content length", objName);
-      StoredObject rawObj = container.getObject(removeTrailingSlash(objName));
-      if (rawObj != null && rawObj.exists()) {
+      StoredObject rawObj = SwiftAPIClient.containerGetObject(container,
+          removeTrailingSlash(objName));
+      if (rawObj != null && SwiftAPIClient.storedObjectExists(rawObj)) {
         res = new SwiftCachedObject(rawObj.getContentLength(),
           Utils.lastModifiedAsLong(rawObj.getLastModified()));
         put(objName, res);

--- a/src/main/java/com/ibm/stocator/metrics/DataMetricCounter.java
+++ b/src/main/java/com/ibm/stocator/metrics/DataMetricCounter.java
@@ -1,0 +1,169 @@
+package com.ibm.stocator.metrics;
+
+import org.apache.spark.TaskContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.annotations.Expose;
+
+public class DataMetricCounter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DataMetricCounter.class);
+  @Expose
+  private final String objectName;
+  @Expose
+  private final String operation;
+  @Expose
+  private final long startTime;
+  @Expose
+  private final long taskId;
+  @Expose
+  private boolean isContainer;
+  @Expose
+  private long endTime;
+  @Expose
+  private long elapsedTime;
+  @Expose
+  private String clvRequestId;
+  @Expose
+  private final WorkingThread workingThread;
+
+  private static Gson sGSON;
+
+  {
+    GsonBuilder builder = new GsonBuilder();
+    builder.excludeFieldsWithoutExposeAnnotation();
+    sGSON = builder.create();
+  }
+
+  public DataMetricCounter(String objName, String methodName, long requestStartTime) {
+    objectName = objName;
+    operation = methodName;
+    startTime = requestStartTime;
+    workingThread = new WorkingThread();
+    TaskContext taskContext = TaskContext.get();
+    taskId = (null == taskContext ? -1 : taskContext.taskAttemptId());
+  }
+
+  public DataMetricCounter(String objName, String methodName, long requestStartTime,
+      boolean isAContainer) {
+    this(objName, methodName, requestStartTime);
+    isContainer = isAContainer;
+  }
+
+  public static class WorkingThread {
+    @Expose
+    private long numBytes = 0;
+    @Expose
+    private long numOperations = 0;
+    @Expose
+    private long blockedTime = 0;
+
+    private long lastUpdated = 0;
+    @Expose
+    private long threadId = -1;
+
+    public WorkingThread() {
+      setLastUpdatedNow();
+      threadId = Thread.currentThread().getId();
+    }
+
+    private void setLastUpdatedNow() {
+      lastUpdated = DataMetricUtilities.getCurrentTimestamp();
+    }
+
+    public long getNumBytes() {
+      return numBytes;
+    }
+
+    public void setNumBytes(long v) {
+      numBytes = v;
+      ++numOperations;
+      setLastUpdatedNow();
+    }
+
+    public void addNumBytes(long v) {
+      numBytes += v;
+      ++numOperations;
+      setLastUpdatedNow();
+    }
+
+    public long getNumOperations() {
+      return numOperations;
+    }
+
+    public long getBlockedTime() {
+      return blockedTime;
+    }
+
+    public void addBlockedTime(long d) {
+      blockedTime += d;
+    }
+
+    public long getLastUpdated() {
+      return lastUpdated;
+    }
+
+    public long getTID() {
+      return threadId;
+    }
+  }
+
+  public String finalizeAndGetCounterSummary() {
+    updateCommonTimes();
+    String counterSummaryJson = sGSON.toJson(this);
+    StringBuilder sb = new StringBuilder("\", \"metrics\":");
+    sb.append(counterSummaryJson);
+    sb.append(",\"e\":\"");
+    return sb.toString();
+  }
+
+  private void updateCommonTimes() {
+    elapsedTime = workingThread.getLastUpdated() - startTime;
+  }
+
+  public String getObjectName() {
+    return objectName;
+  }
+
+  public String getDescription() {
+    return operation;
+  }
+
+  public long getTaskID() {
+    return taskId;
+  }
+
+  public String getClvRequestId() {
+    return clvRequestId;
+  }
+
+  public void setClvRequestId(String requestId) {
+    clvRequestId = requestId;
+  }
+
+  public void updateCounter(long numBytes, long blockedTime) {
+    WorkingThread t = workingThread;
+    if (Thread.currentThread().getId() != t.threadId) {
+      LOG.error(String.format("Current thread is %d, counter thread is %d",
+          Thread.currentThread().getId(), t.threadId));
+    }
+    t.addBlockedTime(blockedTime);
+    t.addNumBytes(numBytes);
+  }
+
+  public long getStartTime() {
+    return startTime;
+  }
+
+  public long getEndTime() {
+    return endTime;
+  }
+
+  public long getElapsedTime() {
+    return elapsedTime;
+  }
+
+}

--- a/src/main/java/com/ibm/stocator/metrics/DataMetricUtilities.java
+++ b/src/main/java/com/ibm/stocator/metrics/DataMetricUtilities.java
@@ -1,0 +1,113 @@
+package com.ibm.stocator.metrics;
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataMetricUtilities {
+  private static boolean sENABLED = false;
+  public static final String DSNET_REQUEST_ID_HEADER = "X-Clv-Request-Id";
+
+  private static final Logger LOG = LoggerFactory.getLogger(DataMetricUtilities.class);
+
+  private DataMetricUtilities() {
+  }
+
+  public static void enableMetricsLogging() {
+    sENABLED = true;
+  }
+
+  public static boolean isMetricsLoggingEnabled() {
+    return sENABLED;
+  }
+
+  public static long getCurrentTimestamp() {
+    long currentTime = 0L;
+    if (sENABLED) {
+      currentTime = System.currentTimeMillis();
+    }
+    return currentTime;
+  }
+
+  public static DataMetricCounter buildDataMetricCounter(long requestStartTime, String objectName,
+      String methodName) {
+    DataMetricCounter dataMetricCounter = null;
+    if (sENABLED) {
+      dataMetricCounter = new DataMetricCounter(objectName, methodName, requestStartTime);
+    }
+    return dataMetricCounter;
+  }
+
+  public static void updateDataMetricCounter(DataMetricCounter dataMetricCounter, long value,
+      long requestStartTime) {
+    if (sENABLED) {
+      long requestDuration = DataMetricUtilities.getCurrentTimestamp() - requestStartTime;
+      if (value < 0) {
+        LOG.warn("Negative values for data metric are not allowed");
+        return;
+      }
+      if (null == dataMetricCounter) {
+        LOG.warn("dataMetricCounter is null. Not persisting the counter.");
+        return;
+      }
+      dataMetricCounter.updateCounter(value, requestDuration);
+    }
+  }
+
+  public static void updateDataMetricCounter(DataMetricCounter dataMetricCounter,
+      HttpResponse httpResponse) {
+    if (sENABLED) {
+      Header clvRequestIdHeader = httpResponse
+          .getFirstHeader(DataMetricUtilities.DSNET_REQUEST_ID_HEADER);
+      if ((null != clvRequestIdHeader) && (null != dataMetricCounter)) {
+        dataMetricCounter.setClvRequestId(clvRequestIdHeader.getValue());
+      }
+    }
+  }
+
+  public static String getCounterSummary(DataMetricCounter dataMetricCounter) {
+    if (sENABLED) {
+      if (null == dataMetricCounter) {
+        LOG.error("Metric counter is null");
+        return "";
+      }
+      return dataMetricCounter.finalizeAndGetCounterSummary();
+    } else {
+      return "";
+    }
+  }
+
+  public static String getCounterSummary(DataMetricCounter dataMetricCounter,
+      Header clvRequestIdHeader) {
+    if (sENABLED) {
+      if (null == dataMetricCounter) {
+        LOG.error("Data metric counter is null");
+        return "";
+      }
+      if (null != clvRequestIdHeader) {
+        dataMetricCounter.setClvRequestId(clvRequestIdHeader.getValue());
+      }
+      return getCounterSummary(dataMetricCounter);
+    } else {
+      return "";
+    }
+  }
+
+  public static long initMetric(String objectName, String logMessage) {
+    return getCurrentTimestamp();
+  }
+
+  public static String closeMetric(String objectName, String methodName, boolean isContainer,
+      long requestStartTime) {
+    if (sENABLED) {
+      DataMetricCounter dataMetricCounter = new DataMetricCounter(objectName, methodName,
+          requestStartTime, isContainer);
+      updateDataMetricCounter(dataMetricCounter, 0, requestStartTime);
+      return getCounterSummary(dataMetricCounter);
+    } else {
+      return "";
+    }
+  }
+
+}


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.


Add metrics of reading and writing times to object store for blocked-time analysis.
Add metrics toggle based on configuration parameter: fs.stocator.metrics.toggle=ON.
Expose httpResponse in InputStreamWrapper.