### PR TITLE
typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Stocator verifies that
 If not modified, the default value of `mapreduce.fileoutputcommitter.marksuccessfuljobs` is `true`.
 
 ## Configuration keys
-Stocator uses configuration keys that can be configured via `core-site.xml` or provided in run time without using `core-sites.xml`. To provide keys in run time use SparkContext variable with
+Stocator uses configuration keys that can be configured via spark's `core-site.xml` or provided in run time without using `core-site.xml`. To provide keys in run time use SparkContext variable with
 
 	sc.hadoopConfiguration.set("KEY","VALUE")
 
-For usage with `core-sites.xml`, see the configuration template located under `conf/core-site.xml.template`.
+For usage with `core-site.xml`, see the configuration template located under `conf/core-site.xml.template`.
 
 
 ## Stocator and IBM Cloud Object Storage (COS)
@@ -224,7 +224,7 @@ Example, configure `<service>` as `myCOS`:
 Now you can use URI
 
 	cos://mybucket.myCos/myobject(s)
-#### COS Connector optional configuration tunning
+#### COS Connector optional configuration tuning
 
 
 | Key | Default | Info |


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.
“DCO 1.1 Signed-off-by: Kenneth Nagin“. 
“DCO” stands for “Developer Certificate of Origin,”
