### PR TITLE
Bump joss, httpclient, and ibmcos versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,15 +62,15 @@
         <findbugs.path>build/findbugs</findbugs.path>
         <slf4j.version>1.7.25</slf4j.version>
         <java.version>1.7</java.version>
-        <joss.version>0.10.2</joss.version>
+        <joss.version>0.10.3</joss.version>
         <hadoop.version>2.7.3</hadoop.version>
         <junit.version>4.12</junit.version>
         <jackson.version>1.9.13</jackson.version>
-        <httpcomponents.httpcore.version>4.4.10</httpcomponents.httpcore.version>
-        <httpcomponents.httpclient.version>4.5.6</httpcomponents.httpclient.version>
+        <httpcomponents.httpcore.version>4.4.11</httpcomponents.httpcore.version>
+        <httpcomponents.httpclient.version>4.5.9</httpcomponents.httpclient.version>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>
-        <ibm.sdk.version>2.4.4</ibm.sdk.version>
+        <ibm.sdk.version>2.5.0</ibm.sdk.version>
         <google.guava.version>27.0.1-jre</google.guava.version>
     </properties>
 

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIDirect.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIDirect.java
@@ -156,7 +156,8 @@ public class SwiftAPIDirect {
         httpPut.addHeader("X-Object-Meta-" + entry.getKey(), entry.getValue());
       }
     }
-    final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true).build();
+    final RequestConfig config = RequestConfig.custom().setExpectContinueEnabled(true)
+        .setNormalizeUri(false).build();
     httpPut.setConfig(config);
     final InputStreamEntity entity = new InputStreamEntity(inputStream, size);
     httpPut.setEntity(entity);

--- a/src/main/java/com/ibm/stocator/fs/swift/SwiftOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/SwiftOutputStream.java
@@ -168,7 +168,8 @@ public class SwiftOutputStream extends OutputStream {
       futureTask = executor.submit(connectionTask);
       do {
         // Wait till the connection is open and the task isn't done
-      } while (!openConnection.get() && !futureTask.isDone());
+      }
+      while (!openConnection.get() && !futureTask.isDone());
     }
   }
 

--- a/src/main/java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java
+++ b/src/main/java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java
@@ -118,7 +118,7 @@ public class SwiftConnectionManager {
     connectionPool.setDefaultSocketConfig(socketConfig);
     rConfig = RequestConfig
                 .custom()
-                .setExpectContinueEnabled(true)
+                .setExpectContinueEnabled(true).setNormalizeUri(false)
                 .setConnectTimeout(connectionConfiguration.getReqConnectTimeout())
                 .setConnectionRequestTimeout(
                     connectionConfiguration.getReqConnectionRequestTimeout())


### PR DESCRIPTION
* upgrading past httpclient 4.5.6 changes request url normalization behavior, to keep the behavior consistent calls to RequestConfig.setNormalizeUri(false) were added.



 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

