### PR TITLE
fix: proper encoding type for listing (url)

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -634,7 +634,7 @@ public class COSAPIClient implements IStoreClient {
         ListObjectsRequest request = new ListObjectsRequest();
         request.setBucketName(mBucket);
         request.setPrefix(key);
-        request.withEncodingType("UTF-8");
+        request.withEncodingType("url");
         request.setDelimiter("/");
         request.setMaxKeys(1);
 


### PR DESCRIPTION
This pr makes sure the encoding for listing keys is set to a valid value. 
