### PR TITLE
Atomic Write support for COS

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Now you can use URI
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |
 | fs.cos.fast.upload | false | enable or disable block upload |
 | fs.stocator.glob.bracket.support | false | if true supports Hadoop string patterns of the form {ab,c{de, fh}}. Due to possible collision with object names, this mode prevents from create an object whose name contains {} |
+| fs.cos.atomic.write | false | enable or disable atomic writes to cos using Etags. When the flag fs.cos.fast.upload write is set true atomic writes will be available only for writes that require only one block. |
 
 ## Stocator and Object Storage based on OpenStack Swift API
 

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Now you can use URI
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |
 | fs.cos.fast.upload | false | enable or disable block upload |
 | fs.stocator.glob.bracket.support | false | if true supports Hadoop string patterns of the form {ab,c{de, fh}}. Due to possible collision with object names, this mode prevents from create an object whose name contains {} |
-| fs.cos.atomic.write | false | enable or disable atomic writes to cos using Etags. When the flag fs.cos.fast.upload write is set true atomic writes will be available only for writes that require only one block. |
+| fs.cos.atomic.write | false | enable or disable atomic writes to COS using Etags. When the flag `fs.cos.fast.upload` is set `true` atomic writes will be available only for writes that require only one block. |
 
 ## Stocator and Object Storage based on OpenStack Swift API
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -117,6 +117,16 @@ class COSBlockOutputStream extends OutputStream {
   private String contentType;
 
   /**
+   * Object's etag for atomic write
+   */
+  private final String mEtag;
+
+  /**
+   * Indicates whether the PutObjectRequest will be atomic or not
+   */
+  private Boolean mAtomicWriteEnabled;
+
+  /**
    * An COS output stream which uploads partitions in a separate pool of
    * threads; different {@link COSDataBlocks.BlockFactory} instances can control
    * where data is buffered.
@@ -129,6 +139,8 @@ class COSBlockOutputStream extends OutputStream {
    * @param contentTypeT contentType
    * @param writeOperationHelperT state of the write operation
    * @param metadata Map<String, String> metadata
+   * @param etag the etag to be used in atomic write (null if no etag exists)
+   * @param atomicWriteEnabled if true the putObject
    * @throws IOException on any problem
    */
   COSBlockOutputStream(COSAPIClient fsT, String keyT, ExecutorService executorServiceT,
@@ -136,7 +148,9 @@ class COSBlockOutputStream extends OutputStream {
       COSDataBlocks.BlockFactory blockFactoryT,
       String contentTypeT,
       COSAPIClient.WriteOperationHelper writeOperationHelperT,
-      Map<String, String> metadata)
+      Map<String, String> metadata,
+      String etag,
+      Boolean atomicWriteEnabled)
       throws IOException {
     fs = fsT;
     key = keyT;
@@ -144,6 +158,8 @@ class COSBlockOutputStream extends OutputStream {
     contentType = contentTypeT;
     blockSize = (int) blockSizeT;
     mMetadata = metadata;
+    mEtag = etag;
+    mAtomicWriteEnabled = atomicWriteEnabled;
     writeOperationHelper = writeOperationHelperT;
     if (blockSize < COSConstants.MULTIPART_MIN_SIZE) {
       throw new IllegalArgumentException("Block size is too small: " + blockSize);
@@ -384,6 +400,16 @@ class COSBlockOutputStream extends OutputStream {
       om.setContentType(contentType);
     } else {
       om.setContentType("application/octet-stream");
+    }
+    // if atomic write is enabled use the etag to ensure put request is atomic
+    if (mAtomicWriteEnabled) {
+      if (mEtag != null) {
+        LOG.debug("Atomic write - setting If-Match header");
+        om.setHeader("If-Match", mEtag);
+      } else {
+        LOG.debug("Atomic write - setting If-None-Match header");
+        om.setHeader("If-None-Match", "*");
+      }
     }
     putObjectRequest.setMetadata(om);
     ListenableFuture<PutObjectResult> putObjectResult =

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -123,6 +123,7 @@ class COSBlockOutputStream extends OutputStream {
 
   /**
    * Indicates whether the PutObjectRequest will be atomic or not
+   * Note that currently only put requests for one block will atomic since there is no atomic CompleteMultipartUploadRequest currently.
    */
   private Boolean mAtomicWriteEnabled;
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -141,7 +141,8 @@ class COSBlockOutputStream extends OutputStream {
    * @param writeOperationHelperT state of the write operation
    * @param metadata Map<String, String> metadata
    * @param etag the etag to be used in atomic write (null if no etag exists)
-   * @param atomicWriteEnabled if true the putObject
+   * @param atomicWriteEnabled if true the putObject for uploads with one block will be atomic
+   * Note that currently only put requests for one block will atomic since there is no atomic CompleteMultipartUploadRequest currently.
    * @throws IOException on any problem
    */
   COSBlockOutputStream(COSAPIClient fsT, String keyT, ExecutorService executorServiceT,

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -123,7 +123,8 @@ class COSBlockOutputStream extends OutputStream {
 
   /**
    * Indicates whether the PutObjectRequest will be atomic or not
-   * Note that currently only put requests for one block will atomic since there is no atomic CompleteMultipartUploadRequest currently.
+   * Note that currently only put requests for one block will atomic since
+   * there is no atomic CompleteMultipartUploadRequest currently.
    */
   private Boolean mAtomicWriteEnabled;
 
@@ -142,7 +143,8 @@ class COSBlockOutputStream extends OutputStream {
    * @param metadata Map<String, String> metadata
    * @param etag the etag to be used in atomic write (null if no etag exists)
    * @param atomicWriteEnabled if true the putObject for uploads with one block will be atomic
-   * Note that currently only put requests for one block will atomic since there is no atomic CompleteMultipartUploadRequest currently.
+   * Note that currently only put requests for one block will atomic since
+   *      there is no atomic CompleteMultipartUploadRequest currently.
    * @throws IOException on any problem
    */
   COSBlockOutputStream(COSAPIClient fsT, String keyT, ExecutorService executorServiceT,

--- a/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
@@ -167,6 +167,9 @@ public class COSConstants {
   public static final String FAST_UPLOAD = ".fast.upload";
   public static final boolean DEFAULT_FAST_UPLOAD = false;
 
+  public static final String ATOMIC_WRITE = ".atomic.write";
+  public static final boolean DEFAULT_ATOMIC_WRITE = true;
+
   public static final String FAST_UPLOAD_BUFFER =
       ".fast.upload.buffer";
   public static final String DEFAULT_FAST_UPLOAD_BUFFER =

--- a/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
@@ -168,7 +168,7 @@ public class COSConstants {
   public static final boolean DEFAULT_FAST_UPLOAD = false;
 
   public static final String ATOMIC_WRITE = ".atomic.write";
-  public static final boolean DEFAULT_ATOMIC_WRITE = true;
+  public static final boolean DEFAULT_ATOMIC_WRITE = false;
 
   public static final String FAST_UPLOAD_BUFFER =
       ".fast.upload.buffer";


### PR DESCRIPTION
This PR adds support for atomic write to COS using COS support for conditional Etags for the PutObjectRequest.

The usage of atomic write is controlled by a new flag - `fs.cos.atomic.write` and it is set by default to `false`.

The logic to use atomic write is the following:
1. If the flag `fs.cos.atomic.write` is set to `true` get the Etag of the current object.
2. If object doesn't exist then the PutObjectRequest will use the Etag `"If-None-Match" : "*"`
3. If the object exists then the PutObjectRequest will use the Etag `"If-Match": "<Etag>"`

Currently there is no support in COS for atomic multipart upload request, so if the flag `fs.cos.fast.upload` is set to `true` then only writes which have size that is less than the configured block size will be atomic since these writes use PutObjectRequest and not a MultipartUpload request.

will only succeed if this is the first PUT to that object name
if this fails because of constraint (concurrent write) then throw an IllegalState exception 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

