### PR TITLE
fix object listing with empty object for flat listing

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -986,19 +986,16 @@ public class COSAPIClient implements IStoreClient {
       for (String comPrefix : commonPrefixes) {
         LOG.trace("Common prefix is {}", comPrefix);
         Path qualifiedPath = keyToQualifiedPath(hostName, comPrefix);
-        if (emptyObjects.containsKey((qualifiedPath).toString()) || emptyObjects.isEmpty()) {
-          FileStatus status = new COSFileStatus(true, false, qualifiedPath);
-          LOG.trace("Match between common prefix and empty object {}. Adding to result", comPrefix);
-          if (filter == null) {
-            memoryCache.putFileStatus(status.getPath().toString(), status);
-            tmpResult.add(status);
-          } else if (filter != null && filter.accept(status.getPath())) {
-            memoryCache.putFileStatus(status.getPath().toString(), status);
-            tmpResult.add(status);
-          } else {
-            LOG.trace("Common prefix {} rejected by path filter during list. Filter {}",
-                status.getPath(), filter);
-          }
+        FileStatus status = new COSFileStatus(true, false, qualifiedPath);
+        if (filter == null) {
+          memoryCache.putFileStatus(status.getPath().toString(), status);
+          tmpResult.add(status);
+        } else if (filter != null && filter.accept(status.getPath())) {
+          memoryCache.putFileStatus(status.getPath().toString(), status);
+          tmpResult.add(status);
+        } else {
+          LOG.trace("Common prefix {} rejected by path filter during list. Filter {}",
+                  status.getPath(), filter);
         }
       }
       boolean isTruncated = objectList.isTruncated();

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestEmptyObjectFlatListing.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestEmptyObjectFlatListing.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.stocator.fs.cos.systemtests;
+
+import java.io.IOException;
+import java.util.Hashtable;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test Globber operations on the data that was not created by Stocator
+ */
+public class TestEmptyObjectFlatListing extends COSFileSystemBaseTest {
+
+  private static Path[] sTestData;
+  private static Path[] sEmptyFiles;
+  private static byte[] sData = "This is file".getBytes();
+  private static Hashtable<String, String> sConf = new Hashtable<String, String>();
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    sConf.put("fs.cos.flat.list", "false");
+    createCOSFileSystem(sConf);
+    if (sFileSystem != null) {
+      createTestData();
+    }
+  }
+
+  private static void createTestData() throws IOException {
+
+    sTestData = new Path[] {
+        new Path(sBaseURI + "/test1/year=2012/month=1/data.csv"),
+        new Path(sBaseURI + "/test1/year=2012/month=10/data.csv"),
+        new Path(sBaseURI + "/test1/year=2012/month=11/data.csv")};
+
+    sEmptyFiles = new Path[] {
+        new Path(sBaseURI + "/test1/year=2012/month=10")};
+
+    for (Path path : sTestData) {
+      createFile(path, sData);
+    }
+    for (Path path : sEmptyFiles) {
+      createEmptyFile(path);
+    }
+
+  }
+
+  @Test
+  public void testListGlobber() throws Exception {
+    Path lPath = new Path(sBaseURI + "/test1/year=2012/");
+    FileStatus[] res = sFileSystem.listStatus(lPath);
+    System.out.println("Stocator returned list of size: " + res.length);
+    // Stocator doesn't list empty objects so we expect the output to be only the three directories
+    for (FileStatus fs: res) {
+      System.out.println("Stocator" + fs.getPath() + " directory " + fs.isDirectory());
+      assertEquals(fs.isDirectory(), true);
+    }
+    assertEquals(res.length, 3);
+  }
+}


### PR DESCRIPTION
When setting Stocator to use flat listing (setting `fs.cos.flat.list` to `true`) Stocator doesn't return the right listing when there is an empty object in the hierarchy.

For example say we have the following objects
```
test1/year=2012/month=1/data.csv
test1/year=2012/month=10/data.csv
test1/year=2012/month=11/data.csv
test1/year=2012/month=10
```
where `test1/year=2012/month=10` is an empty object and the rest are not.

Listing with flat listing set to `false` on `test1/year=2012` will return only the  empty object `month=10`.
For comparison using aws cli for listing without `--recursive` flag would have returned:
```
                           PRE month=1/
                           PRE month=10/
                           PRE month=11/
2020-01-09 14:01:39          0 month=10
```

The reason is due to this [if statement](https://github.com/CODAIT/stocator/blob/20a1b5dd95072a0f32cda840c1996641602115bc/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java#L989):
```
if (emptyObjects.containsKey((qualifiedPath).toString()) || emptyObjects.isEmpty())
```
This determines which of the `commonPrefixes` that were returned from the listing will be included in Stocator listing result.
In this case `emptyObjects.isEmpty()` is `false` and the second condition is `true` only for the `month=10` object.

The right behaviour would have been to add all `commonPrefixes` regardless of the empty objects.
**Note - Stocator doesn't return empty objects in the listing, this behaviour is preserved therefore listing for the above case should return only the "directories".**

The PR removes this condition and adds a test to check this case.

For the case of `fs.cos.flat.list` set to `true` (the default) there should be no `commonPrefixes` so this change doesn't affect this case.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

