### PR TITLE
Atomic write doc update (IBM SDK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Now you can use URI
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |
 | fs.cos.fast.upload | false | enable or disable block upload |
 | fs.stocator.glob.bracket.support | false | if true supports Hadoop string patterns of the form {ab,c{de, fh}}. Due to possible collision with object names, this mode prevents from create an object whose name contains {} |
-| fs.cos.atomic.write | false | enable or disable atomic writes to COS using Etags. When the flag `fs.cos.fast.upload` is set `true` atomic writes will be available only for writes that require only one block. |
+| fs.cos.atomic.write | false | enable or disable atomic write to COS using Etags. Atomic write is available only when the write is done in one chunk. <br> When the flag`fs.cos.fast.upload` is set to `false` atomic write will be available only for write that is lower or equal to `fs.cos.multipart.threshold` size. <br> When the flag `fs.cos.fast.upload` is set to `true` atomic write will be available only for write that require only one block. |
 
 ## Stocator and Object Storage based on OpenStack Swift API
 


### PR DESCRIPTION
Documentation update.
Atomic write is available only for writes that can be done in one chunk.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

