### PR TITLE
update multipart size documentation to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Now you can use URI
 | fs.cos.user.agent.prefix| |User agent prefix |
 | fs.cos.flat.list | true | In flat listing the result will include all objects under specific path prefix, for example bucket/a/b/data.txt, bucket/a/d.data. If listed bucket/a*, then result will include both objects. If flat list is set to flase, then it contains the same list behaviour as community s3a connector. |
 | fs.stocator.cache.size | 2000 | The Guava cache size used by the COS connector |
-| fs.cos.multipart.size | 104857600 | Size in bytes. Define multipart size |
+| fs.cos.multipart.size | 8388608 | Size in bytes. Define multipart size |
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |
 | fs.cos.fast.upload | false | enable or disable block upload |
 | fs.stocator.glob.bracket.support | false | if true supports Hadoop string patterns of the form {ab,c{de, fh}}. Due to possible collision with object names, this mode prevents from create an object whose name contains {} |


### PR DESCRIPTION
Update the default value for `fs.cos.multipart.size` in the documentation to match the value used in the code:
https://github.com/CODAIT/stocator/blob/2c07925057d5e52f4a52f2f5e486f222a8188bc1/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java#L110 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

