### PR TITLE
Adding test for deep hive style partition listing

### DIFF
--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListing.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListing.java
@@ -26,7 +26,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
- * Test Globber operations on the data that was not created by Stocator
+ * Test listing time for objects no created by spark
  */
 public class TestListing extends COSFileSystemBaseTest {
 

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListingDeepHivePartition.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListingDeepHivePartition.java
@@ -49,7 +49,9 @@ public class TestListingDeepHivePartition extends COSFileSystemBaseTest {
     // create files deep hive style partitioing
     for (int i = 0; i < 10; i++) {
       createFile(new Path(sBaseURI + "/testListingDeepHiveStyle/a=" + i
-              + "/b=" + i + "/c=" + i + "/d=" + i + "/e=" + i + "/f" + i), sData);
+              + "/b=" + i + "/c=" + i + "/d=" + i + "/e=" + i
+              + "/g=" + i + "/h=" + i + "/j=" + i + "/k=" + i
+              + "/f" + i), sData);
     }
   }
 
@@ -77,7 +79,7 @@ public class TestListingDeepHivePartition extends COSFileSystemBaseTest {
 
     assertTrue("lists not equal", nonFlatListingRes.length == flatListingRes.size());
     assertFalse("Listing deep hive style partitioning took too long",
-            listingTimeNonFlatListing > 2 * listingTimeFlatListing);
+            listingTimeNonFlatListing > 15 * listingTimeFlatListing);
   }
 
   static List<FileStatus> listRecursive(Path path) throws IOException {

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListingDeepHivePartition.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestListingDeepHivePartition.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.stocator.fs.cos.systemtests;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test listing time deep hive style partitioning with and without flat listing turned on
+ */
+public class TestListingDeepHivePartition extends COSFileSystemBaseTest {
+
+  private static byte[] sData = "This is file".getBytes();
+  private static Hashtable<String, String> sConfFlatListing = new Hashtable<String, String>();
+
+  @BeforeClass
+  public static void setUpClass() throws Exception {
+    sConfFlatListing.put("fs.cos.flat.list", "false");
+    createCOSFileSystem(sConfFlatListing);
+    if (sFileSystem != null) {
+      createTestData();
+    }
+  }
+
+  private static void createTestData() throws IOException {
+    // create files deep hive style partitioing
+    for (int i = 0; i < 10; i++) {
+      createFile(new Path(sBaseURI + "/testListingDeepHiveStyle/a=" + i
+              + "/b=" + i + "/c=" + i + "/d=" + i + "/e=" + i + "/f" + i), sData);
+    }
+  }
+
+  @Test
+  public void testListGlobber() throws Exception {
+    Path dataPath = new Path(sBaseURI + "/testListingDeepHiveStyle");
+
+    // Check with flat listing turned off
+    long startTime = System.nanoTime();
+    List<FileStatus> flatListingRes = listRecursive(dataPath);
+    long endTime = System.nanoTime();
+    long listingTimeNonFlatListing = endTime - startTime;
+    System.out.println("Stocator listing took for dataset starting with part "
+            + listingTimeNonFlatListing + "ns");
+
+    // Check now with flat listing turned on
+    sConfFlatListing.put("fs.cos.flat.list", "true");
+    createCOSFileSystem(sConfFlatListing);
+    startTime = System.nanoTime();
+    FileStatus[] nonFlatListingRes = sFileSystem.listStatus(dataPath);
+    endTime = System.nanoTime();
+    long listingTimeFlatListing = endTime - startTime;
+    System.out.println("Stocator listing took for dataset starting with part "
+            + listingTimeFlatListing + "ns");
+
+    assertTrue("lists not equal", nonFlatListingRes.length == flatListingRes.size());
+    assertFalse("Listing deep hive style partitioning took too long",
+            listingTimeNonFlatListing > 2 * listingTimeFlatListing);
+  }
+
+  static List<FileStatus> listRecursive(Path path) throws IOException {
+    List<FileStatus> res = new ArrayList<>();
+    FileStatus[] lst = sFileSystem.listStatus(path);
+
+    // list recursively
+    for (FileStatus fileStatus: lst) {
+      if (fileStatus.isDirectory()) {
+        res.addAll(listRecursive(fileStatus.getPath()));
+      } else {
+        res.add(fileStatus);
+      }
+    }
+    return res;
+  }
+}


### PR DESCRIPTION
This test checks the performance of a dataset with deep hive style partitioning once with flat listing set to `false` and once with flat listing set to `true`.

Currently this test fails because listing with flat listing set to `false` causes a HEAD request for each folder.
 
note that the non flat listing in this case is expected to be a bit slower because its not done in parallel, but the main reason for it being slower is mainly because of the HEAD requests and not the recursive calls.

Same issue happens when there is a deep folder hierarchy regardless if it's hive style.

Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

