### PR TITLE
Atomic write for MultiPart uploads

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -1485,12 +1485,23 @@ public class COSAPIClient implements IStoreClient {
      * @return the upload result containing the ID
      * @throws IOException IO problem
      */
-    String initiateMultiPartUpload() throws IOException {
+    String initiateMultiPartUpload(Boolean atomicWrite, String etag) throws IOException {
       LOG.debug("Initiating Multipart upload");
+      ObjectMetadata om = newObjectMetadata(-1);
+      // if atomic write is enabled use the etag to ensure put request is atomic
+      if (atomicWrite) {
+        if (etag != null) {
+          LOG.debug("Atomic write - setting If-Match header");
+          om.setHeader("If-Match", etag);
+        } else {
+          LOG.debug("Atomic write - setting If-None-Match header");
+          om.setHeader("If-None-Match", "*");
+        }
+      }
       final InitiateMultipartUploadRequest initiateMPURequest =
           new InitiateMultipartUploadRequest(mBucket,
               key,
-              newObjectMetadata(-1));
+              om);
       try {
         return mClient.initiateMultipartUpload(initiateMPURequest)
             .getUploadId();

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -472,7 +472,7 @@ class COSBlockOutputStream extends OutputStream {
     private final List<ListenableFuture<PartETag>> partETagsFutures;
 
     MultiPartUpload() throws IOException {
-      uploadId = writeOperationHelper.initiateMultiPartUpload();
+      uploadId = writeOperationHelper.initiateMultiPartUpload(mAtomicWriteEnabled, mEtag);
       partETagsFutures = new ArrayList<>(2);
       LOG.debug("Initiated multi-part upload for {} with " + "id '{}'",
           writeOperationHelper, uploadId);


### PR DESCRIPTION
COS now supports [conditional headers](https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-upload#upload-conditional) on multiple uploads.
This PR includes the necessary changes to make stocator support atomic multipart writes.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

