### PR TITLE
decode objects path if url encoded

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -1688,7 +1688,7 @@ public class COSAPIClient implements IStoreClient {
    * @return decoded path string
    */
   private String decodePath(String path, String encoding) {
-    if (encoding.equals("url")) {
+    if (encoding != null && encoding.equals("url")) {
       try {
         path = URLDecoder.decode(path, "UTF-8");
       } catch (UnsupportedEncodingException e) {

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -26,7 +26,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InterruptedIOException;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.util.Map;
 import java.util.List;
 import java.util.Properties;
@@ -888,6 +890,8 @@ public class COSAPIClient implements IStoreClient {
     }
 
     ObjectListing objectList = mClient.listObjects(request);
+    String encoding = objectList.getEncodingType();
+    LOG.debug("Encoding Type: {}", objectList.getEncodingType());
 
     List<S3ObjectSummary> objectSummaries = objectList.getObjectSummaries();
     List<String> commonPrefixes = objectList.getCommonPrefixes();
@@ -905,10 +909,10 @@ public class COSAPIClient implements IStoreClient {
       for (S3ObjectSummary obj : objectSummaries) {
         if (prevObj == null) {
           prevObj = obj;
-          prevObj.setKey(correctPlusSign(targetListKey, prevObj.getKey()));
+          prevObj.setKey(correctPlusSign(targetListKey, decodePath(prevObj.getKey(), encoding)));
           continue;
         }
-        obj.setKey(correctPlusSign(targetListKey, obj.getKey()));
+        obj.setKey(correctPlusSign(targetListKey, decodePath(obj.getKey(), encoding)));
         String objKey = obj.getKey();
 
         LOG.trace("Proceeding key {} from the list ", objKey);
@@ -993,7 +997,7 @@ public class COSAPIClient implements IStoreClient {
           if (stocatorPath.nameWithoutTaskID(objKey)
               .equals(stocatorPath.nameWithoutTaskID(prevObj.getKey()))) {
             // found failed that was not aborted.
-            LOG.trace("Colisiion found between {} and {}", prevObj.getKey(), objKey);
+            LOG.trace("Collision found between {} and {}", prevObj.getKey(), objKey);
             if (prevObj.getSize() < obj.getSize()) {
               LOG.trace("New candidate is {}. Removed {}", obj.getKey(), prevObj.getKey());
               if (cleanup) {
@@ -1674,6 +1678,24 @@ public class COSAPIClient implements IStoreClient {
       return p;
     }
     return path.makeQualified(filesystemURI, workingDir);
+  }
+
+  /**
+   * This method decodes the path string if it is url encoded
+   *
+   * @param path of the file in object storage
+   * @param encoding of the path
+   * @return decoded path string
+   */
+  private String decodePath(String path, String encoding) {
+    if (encoding.equals("url")) {
+      try {
+        path = URLDecoder.decode(path, "UTF-8");
+      } catch (UnsupportedEncodingException e) {
+        LOG.debug("Exception when decoding path: {}", e.getMessage());
+      }
+    }
+    return path;
   }
 
   /**


### PR DESCRIPTION

 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

**Brief Description:** 

When invoking listObjects on CEPH (Red Hat Object Storage) bucket, the returned result s contains:
```
..., u'Key': 'surya2020%2F_SUCCESS',... (Here I notice character / is returned as an encoded value %2F .
```
To resolve this, I first check for "encoding type". If it is "url" encoding, then I decode.