### PR TITLE
Fixing issues with Glob Filter

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/common/ObjectStoreFlatGlobFilter.java
+++ b/src/main/java/com/ibm/stocator/fs/common/ObjectStoreFlatGlobFilter.java
@@ -125,13 +125,7 @@ public class ObjectStoreFlatGlobFilter implements PathFilter {
     boolean match = true;
     for (String pathPattern : parsedPatterns) {
       LOG.trace("accept on {}, path pattern {}, name {}", pathStr, pathPattern, name);
-      if (name != null && name.startsWith("part-")) {
-        LOG.trace("accept on parent {}, path pattern {}",
-            path.getParent().toString(), pathPattern);
-        match = FilenameUtils.wildcardMatch(path.getParent().toString() + "/", pathPattern);
-      } else {
-        match = FilenameUtils.wildcardMatch(pathStr, pathPattern);
-      }
+      match = FilenameUtils.wildcardMatch(pathStr, pathPattern);
       if (match) {
         return match;
       }

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberSpecialChars.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberSpecialChars.java
@@ -19,25 +19,43 @@
 package com.ibm.stocator.fs.cos.systemtests;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Hashtable;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import static com.ibm.stocator.fs.common.FileSystemTestUtils.dumpStats;
 
 /**
  * Test the FileSystem#listStatus() operations
  */
+@RunWith(Parameterized.class)
 public class TestCOSGlobberSpecialChars extends COSFileSystemBaseTest {
+
+  public TestCOSGlobberSpecialChars(Boolean isFlatListing) {
+    flatListing = isFlatListing;
+  }
+
+  private boolean flatListing;
 
   private static Path[] sTestData;
   private static Path[] sEmptyFiles;
   private static byte[] sData = "This is file".getBytes();
+  private static Hashtable<String, String> sConf = new Hashtable<String, String>();
 
-  @BeforeClass
-  public static void setUpClass() throws Exception {
-    createCOSFileSystem();
+  @Parameterized.Parameters(name = "flat listing = {0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] { { true }, { false } });
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    sConf.put("fs.cos.flat.list", String.valueOf(flatListing));
+    createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();
     }
@@ -70,7 +88,11 @@ public class TestCOSGlobberSpecialChars extends COSFileSystemBaseTest {
     for (FileStatus path: paths) {
       System.out.println(path.getPath());
     }
-    assertEquals(dumpStats("/test/*", paths), 2, paths.length);
+    if (flatListing) {
+      assertEquals(dumpStats("/test/*", paths), 2, paths.length);
+    } else {
+      assertEquals(dumpStats("/test/*", paths), 1, paths.length);
+    }
   }
 
 }


### PR DESCRIPTION
The current GlobFilter code doesn't work well when trying to list a path of the form:
```
cos://mybucket.service/mypath/*.parquet
```
If the objects under this path are starting with `part-`

The reason is because for some reason there is a special case in the glob filter for such case:
```Java
      if (name != null && name.startsWith("part-")) {
        LOG.trace("accept on parent {}, path pattern {}",
            path.getParent().toString(), pathPattern);
        match = FilenameUtils.wildcardMatch(path.getParent().toString() + "/", pathPattern);
      } else {
        match = FilenameUtils.wildcardMatch(pathStr, pathPattern);
      }
```

This PR removes the extra logic and only use:
```Java
match = FilenameUtils.wildcardMatch(pathStr, pathPattern);
```
@gilv what was the reason to have this in the first place?


All of the glob tests pass after this change, in addition I have changed the glob tests to run once for flat listing set to `true` (the default) and once for flat listing set to `true` using parameterized tests (changing the expected results accordingly).
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

