### PR TITLE
Set flat listing to false by default

### DIFF
--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -711,7 +711,7 @@ public class COSAPIClient implements IStoreClient {
       // if atomic write is enabled get the current tag if the object already exists
       String mEtag = null;
       if (atomicWriteEnabled && overwrite) {
-        LOG.debug("Atomic write is enabled and overwrite == false,"
+        LOG.debug("Atomic write is enabled and overwrite == true,"
                 + " getting current object etag");
         ObjectMetadata meta = getObjectMetadata(objNameWithoutBucket);
         if (meta != null) {

--- a/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
@@ -185,7 +185,7 @@ public class COSConstants {
   public static final long DEFAULT_PURGE_EXISTING_MULTIPART_AGE = 86400;
 
   public static final String FLAT_LISTING = ".flat.list";
-  public static final boolean DEFAULT_FLAT_LISTING = true;
+  public static final boolean DEFAULT_FLAT_LISTING = false;
 
   public static final String INPUT_FADVISE = "experimental.input.fadvise";
   public static final String INPUT_FADV_NORMAL = "normal";

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSFaultToleranceCleanupMode.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSFaultToleranceCleanupMode.java
@@ -42,6 +42,7 @@ public class TestCOSFaultToleranceCleanupMode extends COSFileSystemBaseTest {
   public static void setUpClass() throws Exception {
     sConf.put("fs.stocator.glob.bracket.support", "true");
     sConf.put("fs.stocator.failure.data.cleanup", "true");
+    sConf.put("fs.cos.flat.list", "true");
     createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobber.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobber.java
@@ -19,6 +19,7 @@
 package com.ibm.stocator.fs.cos.systemtests;
 
 import java.io.IOException;
+import java.util.Hashtable;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -34,10 +35,12 @@ public class TestCOSGlobber extends COSFileSystemBaseTest {
   private static Path[] sTestData;
   private static Path[] sEmptyFiles;
   private static byte[] sData = "This is file".getBytes();
+  private static Hashtable<String, String> sConf = new Hashtable<String, String>();
 
   @BeforeClass
   public static void setUpClass() throws Exception {
-    createCOSFileSystem();
+    sConf.put("fs.cos.flat.list", "true");
+    createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();
     }

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberBracket.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberBracket.java
@@ -40,6 +40,7 @@ public class TestCOSGlobberBracket extends COSFileSystemBaseTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     sConf.put("fs.stocator.glob.bracket.support", "true");
+    sConf.put("fs.cos.flat.list", "true");
     createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberBracketStocator.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberBracketStocator.java
@@ -41,6 +41,7 @@ public class TestCOSGlobberBracketStocator extends COSFileSystemBaseTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     sConf.put("fs.stocator.glob.bracket.support", "true");
+    sConf.put("fs.cos.flat.list", "true");
     createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberSpecialChars.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestCOSGlobberSpecialChars.java
@@ -19,6 +19,7 @@
 package com.ibm.stocator.fs.cos.systemtests;
 
 import java.io.IOException;
+import java.util.Hashtable;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
@@ -34,10 +35,12 @@ public class TestCOSGlobberSpecialChars extends COSFileSystemBaseTest {
   private static Path[] sTestData;
   private static Path[] sEmptyFiles;
   private static byte[] sData = "This is file".getBytes();
+  private static Hashtable<String, String> sConf = new Hashtable<String, String>();
 
   @BeforeClass
   public static void setUpClass() throws Exception {
-    createCOSFileSystem();
+    sConf.put("fs.cos.flat.list", "true");
+    createCOSFileSystem(sConf);
     if (sFileSystem != null) {
       createTestData();
     }


### PR DESCRIPTION
This PR sets the flat listing mode to `false` by default.
The reason is that many code paths in Spark do not expect a flat listing mode and it results in failures which may be hard to detect.

In particular:
1. Recovering partitions for hive tables when using `ALTER TABLE RECOVER PARTITIONS` DDL will fail when flat listing is used.
2. Spark's optimization to list directories in parallel will not be used when flat listing is set to true.

Tests which were written assuming flat listing is set to `true` are now setting the flat listing parameter explicitly.
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

