### PR TITLE
Code changes for upgrading guava to 29.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <powermock.version>2.0.2</powermock.version>
         <mockito.version>2.28.2</mockito.version>
         <amazon.sdk.version>1.11.596</amazon.sdk.version>
-        <google.guava.version>27.0-jre</google.guava.version>
+        <google.guava.version>29.0-jre</google.guava.version>
     </properties>
 
     <dependencies>
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/ibm/stocator/fs/cos/SemaphoredDelegatingExecutor.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/SemaphoredDelegatingExecutor.java
@@ -91,7 +91,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new CallableWithPermitRelease<>(task));
   }
@@ -102,7 +102,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new RunnableWithPermitRelease(task), result);
   }
@@ -113,7 +113,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new RunnableWithPermitRelease(task));
   }


### PR DESCRIPTION
For upgrading the guava version from 27.0-jre to 29.0-jre there were compilation errors because CheckedFuture and related utilities were deprecated in v22 (2017) and removed in v28. So few API changes in the code were required for successful jar build.

Testing is done, apart from the unit tests, certain manual tests were also done, viz HDFS Tests, Spark Shell Tests - To write to a file and read from file, PySpark Shell Tests to read from previously written data which guarantees there is no issue with the changes. 

@gilv 
[https://github.com/CODAIT/stocator/pull/273](url) So the guava version can be updated.