### PR TITLE
Commons codec version update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <junit.version>4.12</junit.version>
         <jackson.version>1.9.13</jackson.version>
         <httpcomponents.httpcore.version>4.4.11</httpcomponents.httpcore.version>
-        <httpcomponents.httpclient.version>4.5.9</httpcomponents.httpclient.version>
+        <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
         <powermock.version>2.0.2</powermock.version>
         <mockito.version>2.28.2</mockito.version>
         <amazon.sdk.version>1.11.596</amazon.sdk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <powermock.version>2.0.2</powermock.version>
         <mockito.version>2.28.2</mockito.version>
         <amazon.sdk.version>1.11.596</amazon.sdk.version>
-        <google.guava.version>27.0-jre</google.guava.version>
+        <google.guava.version>29.0-jre</google.guava.version>
     </properties>
 
     <dependencies>
@@ -201,7 +201,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <powermock.version>2.0.2</powermock.version>
         <mockito.version>2.28.2</mockito.version>
         <amazon.sdk.version>1.11.596</amazon.sdk.version>
-        <google.guava.version>29.0-jre</google.guava.version>
+        <google.guava.version>30.0-jre</google.guava.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <junit.version>4.12</junit.version>
         <jackson.version>1.9.13</jackson.version>
         <httpcomponents.httpcore.version>4.4.11</httpcomponents.httpcore.version>
-        <httpcomponents.httpclient.version>4.5.13</httpcomponents.httpclient.version>
+        <httpcomponents.client5.version>5.0.3</httpcomponents.client5.version>
         <powermock.version>2.0.2</powermock.version>
         <mockito.version>2.28.2</mockito.version>
         <amazon.sdk.version>1.11.596</amazon.sdk.version>
@@ -184,9 +184,9 @@
 		    <version>2.6</version>
 		</dependency>
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpcomponents.httpclient.version}</version>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+    		<artifactId>httpclient5</artifactId>
+            <version>${httpcomponents.client5.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>commons-logging</artifactId>

--- a/src/main/java/com/ibm/stocator/fs/cos/SemaphoredDelegatingExecutor.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/SemaphoredDelegatingExecutor.java
@@ -91,7 +91,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new CallableWithPermitRelease<>(task));
   }
@@ -102,7 +102,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new RunnableWithPermitRelease(task), result);
   }
@@ -113,7 +113,7 @@ class SemaphoredDelegatingExecutor extends ForwardingListeningExecutorService {
       queueingPermits.acquire();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      return Futures.immediateFailedCheckedFuture(e);
+      return Futures.immediateFailedFuture(e);
     }
     return super.submit(new RunnableWithPermitRelease(task));
   }


### PR DESCRIPTION
@gilv 
In the twist lock scan report for CVE - PRISMA-2021-0055, the fix is in version 1.13 of commons-codec.
This version is available with httpclient5 version 5.0.3, the version version upgrade for httpclient is done.

While doing this upgrade, some code changes were required in 1.1.4-SNAPSHOT -ibm-sdk branch, there is discrepancy for master and ibm-sdk branch. So whatever is in master should be put in SDK branch also - else there will be compilation errors.
The discrepancy were in these files and line numbers are also mentioned below :
1. Master Branch [https://github.com/CODAIT/stocator/blob/5c336dca1e5fdd9c3ba34250f3e04c5f8785d92c/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIDirect.java#L158](url) and SDK Branch [https://github.com/CODAIT/stocator/blob/d9f20b1c7a852817b4a962e1fa6dab4d8f236ac7/src/main/java/com/ibm/stocator/fs/swift/SwiftAPIDirect.java#L158](url) .setNormalizeUri(false) method.
2. Master Branch [https://github.com/CODAIT/stocator/blob/5c336dca1e5fdd9c3ba34250f3e04c5f8785d92c/s[…]java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java ](url)                                                                                                                                                                                                                                                                         SDKBranch [https://github.com/CODAIT/stocator/blob/d9f20b1c7a852817b4a962e1fa6dab4d8f236ac7/s[…]java/com/ibm/stocator/fs/swift/http/SwiftConnectionManager.java](url)                                                                                                                                                                                                                                                .setNormalizeUri(false) method.

Also httpclient5 version 5.0.3 is also a fix for CVE CVE-2020-13956.

There is success in building jar, testing is done, apart from the unit tests, certain manual tests are also done.