### PR TITLE
Refactor atomic write

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Now you can use URI
 | fs.cos.proxy.password| |Password for authenticating with proxy server |
 | fs.cos.proxy.domain| |Domain for authenticating with proxy server |
 | fs.cos.user.agent.prefix| |User agent prefix |
-| fs.cos.flat.list | true | In flat listing the result will include all objects under specific path prefix, for example bucket/a/b/data.txt, bucket/a/d.data. If listed bucket/a*, then result will include both objects. If flat list is set to flase, then it contains the same list behaviour as community s3a connector. |
+| fs.cos.flat.list | false | In flat listing the result will include all objects under specific path prefix, for example bucket/a/b/data.txt, bucket/a/d.data. If listed bucket/a*, then result will include both objects. If flat list is set to flase, then it contains the same list behaviour as community s3a connector. |
 | fs.stocator.cache.size | 2000 | The Guava cache size used by the COS connector |
 | fs.cos.multipart.size | 8388608 | Size in bytes. Define multipart size |
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Now you can use URI
 | fs.cos.multipart.threshold | Max Integer | minimum size in bytes before we start a multipart uploads, default is max integer |
 | fs.cos.fast.upload | false | enable or disable block upload |
 | fs.stocator.glob.bracket.support | false | if true supports Hadoop string patterns of the form {ab,c{de, fh}}. Due to possible collision with object names, this mode prevents from create an object whose name contains {} |
-| fs.cos.atomic.write | false | enable or disable atomic write to COS using Etags. Atomic write is available only when the write is done in one chunk. <br> When the flag`fs.cos.fast.upload` is set to `false` atomic write will be available only for write that is lower or equal to `fs.cos.multipart.threshold` size. <br> When the flag `fs.cos.fast.upload` is set to `true` atomic write will be available only for write that require only one block. |
+| fs.cos.atomic.write | false | enable or disable atomic write to COS using conditional requests. <br> When the flag is set to true and the operation is create with `overwrite == false` <br> a conditional header will be used to handle race conditions for mutliple writers. <br> If the path gets created between `fs.create` and `stream.close` by an external writer <br> the close operation will fail and the object will not be written |
 
 ## Stocator and Object Storage based on OpenStack Swift API
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -713,7 +713,7 @@ public class COSAPIClient implements IStoreClient {
       // will fail in case of a concurrent write operation
       if (overwrite == false && !atomicWriteEnabled) {
         LOG.warn("ovewrite == false and atomic write mode is not enabled " +
-                "the object will be overwritten");
+                "the object will be overwritten if already exists");
       }
       Boolean avoidOverwrite = atomicWriteEnabled && !overwrite;
       if (blockUploadEnabled) {
@@ -1557,15 +1557,17 @@ public class COSAPIClient implements IStoreClient {
 
     /**
      * Start the multipart upload process.
+     * @param avoidOverwrite if true will avoid overwriting an existing object by using
+     *                       an `If-None-Match` set to `*`
      * @return the upload result containing the ID
      * @throws IOException IO problem
      */
-    String initiateMultiPartUpload(Boolean atomicWrite) throws IOException {
+    String initiateMultiPartUpload(Boolean avoidOverwrite) throws IOException {
       LOG.debug("Initiating Multipart upload");
       ObjectMetadata om = newObjectMetadata(-1);
       // if atomic write is enabled use If-None-Match header
       // to ensure the write is atomic
-      if (atomicWrite) {
+      if (avoidOverwrite) {
         LOG.debug("Atomic write - setting If-None-Match header");
         om.setHeader("If-None-Match", "*");
       }

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -709,11 +709,11 @@ public class COSAPIClient implements IStoreClient {
         objNameWithoutBucket = objName.substring(mBucket.length() + 1);
       }
       // Avoid overwrite is enabled when atomic write is set to true and this is not an overwrite
-      // request. in this case an `If-None-Match` header will be used with `*` to make sure the write
-      // will fail in case of a concurrent write operation
+      // request. in this case an `If-None-Match` header will be used with `*` to make sure the
+      // write will fail in case of a concurrent write operation
       if (overwrite == false && !atomicWriteEnabled) {
-        LOG.warn("ovewrite == false and atomic write mode is not enabled " +
-                "the object will be overwritten if already exists");
+        LOG.warn("overwrite == false and atomic write mode is not enabled "
+                + "the object will be overwritten if already exists");
       }
       Boolean avoidOverwrite = atomicWriteEnabled && !overwrite;
       if (blockUploadEnabled) {

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -1568,7 +1568,7 @@ public class COSAPIClient implements IStoreClient {
       // if atomic write is enabled use If-None-Match header
       // to ensure the write is atomic
       if (avoidOverwrite) {
-        LOG.debug("Atomic write - setting If-None-Match header");
+        LOG.debug("Avoid overwrite - setting If-None-Match header");
         om.setHeader("If-None-Match", "*");
       }
       final InitiateMultipartUploadRequest initiateMPURequest =

--- a/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSBlockOutputStream.java
@@ -115,16 +115,12 @@ class COSBlockOutputStream extends OutputStream {
   private String contentType;
 
   /**
-   * Object's etag for atomic write
-   */
-  private final String mEtag;
-
-  /**
    * Indicates whether the PutObjectRequest will be atomic or not
-   * Note that currently only put requests for one block will atomic since
-   * there is no atomic CompleteMultipartUploadRequest currently.
+   * atomic write is set when the flag is enabled and this is not an overwrite request
+   * in this case an `If-None-Match` header will be used with `*` to make sure the write
+   * will fail in case of a concurrent write operation
    */
-  private Boolean mAtomicWriteEnabled;
+  private Boolean mAtomicWrite;
 
   /**
    * An COS output stream which uploads partitions in a separate pool of
@@ -139,10 +135,7 @@ class COSBlockOutputStream extends OutputStream {
    * @param contentTypeT contentType
    * @param writeOperationHelperT state of the write operation
    * @param metadata Map<String, String> metadata
-   * @param etag the etag to be used in atomic write (null if no etag exists)
-   *     * @param atomicWriteEnabled if true the putObject for uploads with one block will be atomic
-   *     * Note that currently only put requests for one block will atomic since
-   *     *      there is no atomic CompleteMultipartUploadRequest currently.
+   * @param atomicWrite if true the putObject for uploads with one block will be atomic
    * @throws IOException on any problem
    */
   COSBlockOutputStream(COSAPIClient fsT, String keyT, ExecutorService executorServiceT,
@@ -151,8 +144,7 @@ class COSBlockOutputStream extends OutputStream {
       String contentTypeT,
       COSAPIClient.WriteOperationHelper writeOperationHelperT,
       Map<String, String> metadata,
-      String etag,
-      Boolean atomicWriteEnabled)
+      Boolean atomicWrite)
       throws IOException {
     fs = fsT;
     key = keyT;
@@ -160,8 +152,7 @@ class COSBlockOutputStream extends OutputStream {
     contentType = contentTypeT;
     blockSize = (int) blockSizeT;
     mMetadata = metadata;
-    mEtag = etag;
-    mAtomicWriteEnabled = atomicWriteEnabled;
+    mAtomicWrite = atomicWrite;
     writeOperationHelper = writeOperationHelperT;
     if (blockSize < COSConstants.MULTIPART_MIN_SIZE) {
       throw new IllegalArgumentException("Block size is too small: " + blockSize);
@@ -403,15 +394,11 @@ class COSBlockOutputStream extends OutputStream {
     } else {
       om.setContentType("application/octet-stream");
     }
-    // if atomic write is enabled use the etag to ensure put request is atomic
-    if (mAtomicWriteEnabled) {
-      if (mEtag != null) {
-        LOG.debug("Atomic write - setting If-Match header");
-        om.setHeader("If-Match", mEtag);
-      } else {
-        LOG.debug("Atomic write - setting If-None-Match header");
-        om.setHeader("If-None-Match", "*");
-      }
+    // if atomic write is enabled use If-None-Match header
+    // to ensure the write is atomic
+    if (mAtomicWrite) {
+      LOG.debug("Atomic write - setting If-None-Match header");
+      om.setHeader("If-None-Match", "*");
     }
     putObjectRequest.setMetadata(om);
     ListenableFuture<PutObjectResult> putObjectResult =
@@ -472,7 +459,7 @@ class COSBlockOutputStream extends OutputStream {
     private final List<ListenableFuture<PartETag>> partETagsFutures;
 
     MultiPartUpload() throws IOException {
-      uploadId = writeOperationHelper.initiateMultiPartUpload(mAtomicWriteEnabled, mEtag);
+      uploadId = writeOperationHelper.initiateMultiPartUpload(mAtomicWrite);
       partETagsFutures = new ArrayList<>(2);
       LOG.debug("Initiated multi-part upload for {} with " + "id '{}'",
           writeOperationHelper, uploadId);

--- a/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
@@ -85,12 +85,11 @@ public class COSOutputStream extends OutputStream {
   private final COSAPIClient fs;
 
   /**
-   * Indicates whether the PutObjectRequest will be atomic or not
-   * atomic write is set when the flag is enabled and this is not an overwrite request
+   * Indicates whether the PutObjectRequest will avoid overwriting an existing object
    * in this case an `If-None-Match` header will be used with `*` to make sure the write
    * will fail in case of a concurrent write operation
    */
-  private Boolean mAtomicWrite;
+  private Boolean mAvoidOverwrite;
 
   /**
    * Constructor for an output stream of an object in COS
@@ -101,16 +100,17 @@ public class COSOutputStream extends OutputStream {
    * @param contentType the content type written to the output stream
    * @param metadata the object`s metadata
    * @param transfersT TransferManager
-   * @param atomicWrite if true the putObject will be atomic mea
+   * @param avoidOverwrite if true will avoid overwriting an existing object by using
+   *                       an `If-None-Match` set to `*`
    * @param fsT COSAPIClient
    *
    * @throws IOException if error
    */
   public COSOutputStream(String bucketName, String key, AmazonS3 client, String contentType,
       Map<String, String> metadata, TransferManager transfersT,
-      COSAPIClient fsT, Boolean atomicWrite) throws IOException {
+      COSAPIClient fsT, Boolean avoidOverwrite) throws IOException {
     mBucketName = bucketName;
-    mAtomicWrite = atomicWrite;
+    mAvoidOverwrite = avoidOverwrite;
     transfers = transfersT;
     fs = fsT;
     // Remove the bucket name prefix from key path
@@ -168,10 +168,10 @@ public class COSOutputStream extends OutputStream {
       om.setContentLength(mBackupFile.length());
       om.setContentType(mContentType);
       om.setUserMetadata(mMetadata);
-      // if atomic write is enabled use If-None-Match header
+      // if avoid overwrite is enabled use If-None-Match header
       // to ensure the write is atomic
-      if (mAtomicWrite) {
-        LOG.debug("Atomic write - setting If-None-Match header");
+      if (mAvoidOverwrite) {
+        LOG.debug("Avoid Overwrite - setting If-None-Match header");
         om.setHeader("If-None-Match", "*");
       }
 

--- a/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
@@ -85,14 +85,12 @@ public class COSOutputStream extends OutputStream {
   private final COSAPIClient fs;
 
   /**
-   * Object's etag for atomic write
-   */
-  private final String mEtag;
-
-  /**
    * Indicates whether the PutObjectRequest will be atomic or not
+   * atomic write is set when the flag is enabled and this is not an overwrite request
+   * in this case an `If-None-Match` header will be used with `*` to make sure the write
+   * will fail in case of a concurrent write operation
    */
-  private Boolean mAtomicWriteEnabled;
+  private Boolean matomicWrite;
 
   /**
    * Constructor for an output stream of an object in COS
@@ -103,18 +101,16 @@ public class COSOutputStream extends OutputStream {
    * @param contentType the content type written to the output stream
    * @param metadata the object`s metadata
    * @param transfersT TransferManager
-   * @param etag the etag to be used in atomic write (null if no etag exists)
-   * @param atomicWriteEnabled if true the putObject
+   * @param atomicWrite if true the putObject will be atomic mea
    * @param fsT COSAPIClient
    *
    * @throws IOException if error
    */
   public COSOutputStream(String bucketName, String key, AmazonS3 client, String contentType,
       Map<String, String> metadata, TransferManager transfersT,
-      COSAPIClient fsT, String etag, Boolean atomicWriteEnabled) throws IOException {
+      COSAPIClient fsT, Boolean atomicWrite) throws IOException {
     mBucketName = bucketName;
-    mEtag = etag;
-    mAtomicWriteEnabled = atomicWriteEnabled;
+    matomicWrite = atomicWrite;
     transfers = transfersT;
     fs = fsT;
     // Remove the bucket name prefix from key path
@@ -172,15 +168,11 @@ public class COSOutputStream extends OutputStream {
       om.setContentLength(mBackupFile.length());
       om.setContentType(mContentType);
       om.setUserMetadata(mMetadata);
-      // if atomic write is enabled use the etag to ensure put request is atomic
-      if (mAtomicWriteEnabled) {
-        if (mEtag != null) {
-          LOG.debug("Atomic write - setting If-Match header");
-          om.setHeader("If-Match", mEtag);
-        } else {
-          LOG.debug("Atomic write - setting If-None-Match header");
-          om.setHeader("If-None-Match", "*");
-        }
+      // if atomic write is enabled use If-None-Match header
+      // to ensure the write is atomic
+      if (matomicWrite) {
+        LOG.debug("Atomic write - setting If-None-Match header");
+        om.setHeader("If-None-Match", "*");
       }
 
       PutObjectRequest putObjectRequest = new PutObjectRequest(mBucketName, mKey, mBackupFile);

--- a/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSOutputStream.java
@@ -90,7 +90,7 @@ public class COSOutputStream extends OutputStream {
    * in this case an `If-None-Match` header will be used with `*` to make sure the write
    * will fail in case of a concurrent write operation
    */
-  private Boolean matomicWrite;
+  private Boolean mAtomicWrite;
 
   /**
    * Constructor for an output stream of an object in COS
@@ -110,7 +110,7 @@ public class COSOutputStream extends OutputStream {
       Map<String, String> metadata, TransferManager transfersT,
       COSAPIClient fsT, Boolean atomicWrite) throws IOException {
     mBucketName = bucketName;
-    matomicWrite = atomicWrite;
+    mAtomicWrite = atomicWrite;
     transfers = transfersT;
     fs = fsT;
     // Remove the bucket name prefix from key path
@@ -170,7 +170,7 @@ public class COSOutputStream extends OutputStream {
       om.setUserMetadata(mMetadata);
       // if atomic write is enabled use If-None-Match header
       // to ensure the write is atomic
-      if (matomicWrite) {
+      if (mAtomicWrite) {
         LOG.debug("Atomic write - setting If-None-Match header");
         om.setHeader("If-None-Match", "*");
       }

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/COSBaseTest.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/COSBaseTest.java
@@ -136,17 +136,29 @@ public class COSBaseTest extends Assert {
   }
 
   /**
-   * Create a file with the given data.
+   * Create a file with the given data (using overwrite)
    *
    * @param path path to write
    * @param sourceData source dataset
    * @throws IOException on any problem
    */
-
   protected static void createFile(Path path, byte[] sourceData) throws IOException {
+    createFile(path, sourceData, true);
+  }
+
+  /**
+   * Create a file with the given data (using overwrite)
+   *
+   * @param path path to write
+   * @param sourceData source dataset
+   * @param overwrite whether to use overwrite
+   * @throws IOException on any problem
+   */
+  protected static void createFile(Path path, byte[] sourceData,
+                                   boolean overwrite) throws IOException {
     if (sFileSystem != null) {
       System.out.println("Create file " + path.toString());
-      FSDataOutputStream out = sFileSystem.create(path);
+      FSDataOutputStream out = sFileSystem.create(path, overwrite);
       out.write(sourceData, 0, sourceData.length);
       out.close();
     }

--- a/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestAtomicWrite.java
+++ b/src/test/java/com/ibm/stocator/fs/cos/systemtests/TestAtomicWrite.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.ibm.stocator.fs.cos.systemtests;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Hashtable;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ * Test Atomic write using cos conditional requests
+ */
+@RunWith(Parameterized.class)
+public class TestAtomicWrite extends COSFileSystemBaseTest {
+  private Hashtable<String, String> sConf = new Hashtable<String, String>();
+  private Boolean fastUpload;
+  private Boolean multiPart;
+
+  @Parameterized.Parameters(name = "fastUpload = {0}, multiPart = {1}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][] {
+            // fastUpload = false, multiPart = false
+            { false, false },
+            // fastUpload = false, multiPart = true
+            { false, true },
+            // fastUpload = true, multiPart = false
+            { true , false },
+            // fastUpload = true, multiPart = true
+            { true , true }
+    });
+  }
+
+  public TestAtomicWrite(boolean fstUpload, boolean mltPart) throws Exception {
+    fastUpload = fstUpload;
+    multiPart = mltPart;
+    sConf.put("fs.cos.atomic.write", "true");
+    sConf.put("fs.cos.fast.upload", Boolean.toString(fastUpload));
+    // tune multipart configuration to a smaller size for the test
+    if (multiPart) {
+      sConf.put("fs.cos.multipart.threshold", Integer.toString(5 * 1024 * 1024)); // 5MB
+      sConf.put("fs.cos.multipart.size", Integer.toString(5 * 1024 * 1024)); // 5MB
+    }
+    createCOSFileSystem(sConf);
+  }
+
+  /**
+   * Checks writing an object when overwrite == false
+   * In this case the write should fail if an object already exists at the destination
+   * The If-None-Match should be set to * preventing the write from succeeding
+   * @throws Exception
+   */
+  @Test
+  public void testIfNoneMatchObjectExists() throws Exception {
+    Path p = new Path(sBaseURI + "/atomicwrite_fastupload_"
+            + fastUpload + "_multipart_" + multiPart + "/a.txt");
+    // create the object without overwrite
+    String firstFile = "Some text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      firstFile += createDataSize(1024 * 8);
+    }
+    createFile(p, firstFile.getBytes(), false);
+
+    // Now try to create the same file with different content again without overwrite
+    // should fail as a file already exists
+    String secondFile = "Some new text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      secondFile += createDataSize(1024 * 8);
+    }
+
+    try {
+      createFile(p, secondFile.getBytes(), false);
+    } catch (IOException e) {
+      assert (e.getMessage().contains(
+              "At least one of the preconditions you specified did not hold"));
+    }
+  }
+
+  /**
+   * Checks writing an object with overwrite == true when the destination object doesn't exist
+   * at the time of the request.
+   * If in between another writing succeeded the write operation should fail as it
+   * assumed that the object doesn't exist.
+   * The If-None-Match should be set to * preventing the first write operation from succeeding
+   * @throws Exception
+   */
+  @Test
+  public void testIfNonMatchObjectNotExists() throws Exception {
+    Path p = new Path(sBaseURI + "/atomicwrite_fastupload_"
+            + fastUpload + "_multipart_" + multiPart + "/b.txt");
+    // create a request that will try to overwrite this object
+    // the object doesn't exist yet so If-None-Match: * should be used
+    // the write doesn't finish at this stage as close on the stream was not called yet
+    FSDataOutputStream out = sFileSystem.create(p, true);
+    String firstFile = "Some text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      firstFile += createDataSize(1024 * 8);
+    }
+    out.write(firstFile.getBytes(), 0, firstFile.length());
+
+    // create an object in between that is being written to storage
+    String secondFile = "Some new text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      secondFile += createDataSize(1024 * 8);
+    }
+    createFile(p, secondFile.getBytes());
+
+    // close the request for the first write
+    // this should fail because a new object was written in between
+    try {
+      out.close();
+    } catch (IOException e) {
+      assert (e.getMessage().contains(
+              "At least one of the preconditions you specified did not hold"));
+    }
+  }
+
+  /**
+   * Checks writing an object with overwrite == true when the destination object already exists at
+   * the time of writing.
+   * If in between another writing succeeded in overwriting the destination object the
+   * write operation should fail as it assumed it is overwriting the original destination object.
+   * The If-Match should be set to the original destination object Etag preventing the first write
+   * operation from succeeding
+   * @throws Exception
+   */
+  @Test
+  public void testIfMatchObjectExists() throws Exception {
+    Path p = new Path(sBaseURI + "/atomicwrite_fastupload_"
+            + fastUpload + "_multipart_" + multiPart + "/c.txt");
+    // create an object
+    String firstFile = "Some text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      firstFile += createDataSize(1024 * 8);
+    }
+    createFile(p, firstFile.getBytes());
+
+    // create a request that will try to overwrite this object
+    // the destination object exists so an If-Match header with the object Etag should be used
+    // the write doesn't finish at this stage as close on the stream was not called yet
+    FSDataOutputStream out = sFileSystem.create(p, true);
+    String secondFile = "Some between text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      secondFile += createDataSize(1024 * 8);
+    }
+    out.write(secondFile.getBytes(), 0, secondFile.length());
+
+    // overwrite the original object in between so its Etag changes
+    String thirdFile = "Some new text";
+    if (multiPart) {
+      // create large enough file to trigger multipart upload
+      thirdFile += createDataSize(1024 * 8);
+    }
+    createFile(p, thirdFile.getBytes());
+
+    // close the request for the overwrite object
+    try {
+      out.close();
+    } catch (IOException e) {
+      assert (e.getMessage().contains(
+              "At least one of the preconditions you specified did not hold"));
+    }
+  }
+
+  /**
+   * Creates a string of size @msgSize in KB.
+   */
+  private static String createDataSize(int msgSize) {
+    // Java chars are 2 bytes but we don't need to divide by 2 since
+    // only 1 byte is used for common characters in string encoding
+    msgSize = msgSize * 1024;
+    StringBuilder sb = new StringBuilder(msgSize);
+    for (int i = 0; i < msgSize; i++) {
+      sb.append('a');
+    }
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
This PR adds tests for the atomic write feature and enables atomic write only when overwrite is set to `false`
It also updates the README to set flat listing to `false` by default following #276 
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

