### PR TITLE
Added support for STS session token

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The following is the list of the configuration keys. `<service>` can be any valu
 | --- | ------------ | ------------- |
 |fs.cos.`<service>`.access.key | Access key  | mandatory
 |fs.cos.`<service>`.secret.key  | Secret key | mandatory
+|fs.cos.`<service>`.session.token  | Session token | optional
 |fs.cos.`<service>`.endpoint | COS endpoint | mandatory
 |fs.cos.`<service>`.v2.signer.type |  Signer type  | optional
 
@@ -223,6 +224,10 @@ Example, configure `<service>` as `myCOS`:
 	<property>
 		<name>fs.cos.myCos.secret.key</name>
 		<value>SECRET KEY</value>
+	</property>
+	<property>
+		<name>fs.cos.myCos.session.token</name>
+		<value>SESSION TOKEN</value>
 	</property>
 	<property>
 		<name>fs.cos.myCos.v2.signer.type</name>

--- a/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSAPIClient.java
@@ -55,7 +55,9 @@ import com.ibm.stocator.fs.cos.COSInputStream;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.s3.S3ClientOptions;
@@ -138,6 +140,7 @@ import static com.ibm.stocator.fs.cos.COSConstants.REQUEST_TIMEOUT;
 import static com.ibm.stocator.fs.cos.COSConstants.AUTO_BUCKET_CREATE_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.ACCESS_KEY_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.SECRET_KEY_COS_PROPERTY;
+import static com.ibm.stocator.fs.cos.COSConstants.SESSION_TOKEN_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.BLOCK_SIZE_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.COS_BUCKET_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.ENDPOINT_URL_COS_PROPERTY;
@@ -278,6 +281,7 @@ public class COSAPIClient implements IStoreClient {
     // Define COS client
     String accessKey = props.getProperty(ACCESS_KEY_COS_PROPERTY);
     String secretKey = props.getProperty(SECRET_KEY_COS_PROPERTY);
+    String sessionToken = props.getProperty(SESSION_TOKEN_COS_PROPERTY);
 
     if (accessKey == null) {
       throw new ConfigurationParseException("Access KEY is empty. Please provide valid access key");
@@ -285,9 +289,13 @@ public class COSAPIClient implements IStoreClient {
     if (secretKey == null) {
       throw new ConfigurationParseException("Secret KEY is empty. Please provide valid secret key");
     }
+    AWSCredentials creds;
+    if (sessionToken == null) {
+      creds = new BasicAWSCredentials(accessKey, secretKey);
+    } else {
+      creds = new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+    }
 
-    BasicAWSCredentials creds =
-        new BasicAWSCredentials(accessKey, secretKey);
     ClientConfiguration clientConf = new ClientConfiguration();
 
     int maxThreads = Utils.getInt(conf, FS_COS, FS_ALT_KEYS, MAX_THREADS,

--- a/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/COSConstants.java
@@ -52,6 +52,9 @@ public class COSConstants {
   public static final String SECRET_KEY = ".secret.key";
   public static final String SECRET_KEY_COS_PROPERTY = FS_COS + SECRET_KEY;
 
+  public static final String SESSION_TOKEN = ".session.token";
+  public static final String SESSION_TOKEN_COS_PROPERTY = FS_COS + SESSION_TOKEN;
+
   public static final String ENDPOINT_URL = ".endpoint";
   public static final String ENDPOINT_URL_COS_PROPERTY = FS_COS + ENDPOINT_URL;
 

--- a/src/main/java/com/ibm/stocator/fs/cos/ConfigurationHandler.java
+++ b/src/main/java/com/ibm/stocator/fs/cos/ConfigurationHandler.java
@@ -30,6 +30,8 @@ import static com.ibm.stocator.fs.cos.COSConstants.ACCESS_KEY;
 import static com.ibm.stocator.fs.cos.COSConstants.ACCESS_KEY_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.SECRET_KEY;
 import static com.ibm.stocator.fs.cos.COSConstants.SECRET_KEY_COS_PROPERTY;
+import static com.ibm.stocator.fs.cos.COSConstants.SESSION_TOKEN;
+import static com.ibm.stocator.fs.cos.COSConstants.SESSION_TOKEN_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.ENDPOINT_URL;
 import static com.ibm.stocator.fs.cos.COSConstants.ENDPOINT_URL_COS_PROPERTY;
 import static com.ibm.stocator.fs.cos.COSConstants.AUTO_BUCKET_CREATE;
@@ -90,6 +92,8 @@ public final class ConfigurationHandler {
         ACCESS_KEY_COS_PROPERTY, false);
     Utils.updateProperty(conf, prefix, altPrefix, SECRET_KEY, props,
         SECRET_KEY_COS_PROPERTY, false);
+    Utils.updateProperty(conf, prefix, altPrefix, SESSION_TOKEN, props,
+        SESSION_TOKEN_COS_PROPERTY, false);
     Utils.updateProperty(conf, prefix, altPrefix, ENDPOINT_URL, props,
         ENDPOINT_URL_COS_PROPERTY, false);
     Utils.updateProperty(conf, prefix, altPrefix, AUTO_BUCKET_CREATE, props,


### PR DESCRIPTION
With this feature you can use a temporary set of credentials obtained from STS (Secure Token Service)
 
Developer's Certificate of Origin 1.1

       By making a contribution to this project, I certify that:

       (a) The contribution was created in whole or in part by me and I
           have the right to submit it under the Apache License 2.0; or

       (b) The contribution is based upon previous work that, to the best
           of my knowledge, is covered under an appropriate open source
           license and I have the right under that license to submit that
           work with modifications, whether created in whole or in part
           by me, under the same open source license (unless I am
           permitted to submit under a different license), as indicated
           in the file; or

       (c) The contribution was provided directly to me by some other
           person who certified (a), (b) or (c) and I have not modified
           it.

       (d) I understand and agree that this project and the contribution
           are public and that a record of the contribution (including all
           personal information I submit with it, including my sign-off) is
           maintained indefinitely and may be redistributed consistent with
           this project or the open source license(s) involved.

